### PR TITLE
Restructure into custom_component template & pass ble adaptor to Ruuvi lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Defaults to ruuvi ble_communicator default (at this point is `hci0`)
   - platform: ruuvi-hass
     mac: 'MA:CA:DD:RE:SS:01'
     name: 'balcony'
-    adapted: 'hci0' 
+    adapter: 'hci0' 
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ruuvi_hass
 RuuviTag sensor for hass.io
 
-Copy ruuvi-hass.py to <config folder>/custom_components/sensor/ (e.g. /home/homeassistant/.homeassistant/custom_components/sensor/ruuvi-hass.py)
+Copy the contents of `custom_components` in this repo to `<config folder>/custom_components` (e.g. `/home/homeassistant/.homeassistant/custom_components/`).
 
 The configuration.yaml has to be edited like this
 ```

--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ Defaults to ruuvi ble_communicator default (at this point is `hci0`)
 
 ## Contributors 
 [JonasR-](https://github.com/JonasR-) (author)
+[PieterGit](https://github.com/PieterGit)
+[salleq](https://github.com/salleq)
 [smaisidoro](https://github.com/sergioisidoro)

--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ sensor:
     mac: 'MA:CA:DD:RE:SS:01'
     name: 'bathroom'
 ```
+
+If you need you can pass the ble adapter as well.
+Run `hciconfig` to see which ones are available on your machine / env
+Defaults to ruuvi ble_communicator default (at this point is `hci0`)
+
+```
+  - platform: ruuvi-hass
+    mac: 'MA:CA:DD:RE:SS:01'
+    name: 'balcony'
+    adapted: 'hci0' 
+```
+
+
+## Contributors 
+[JonasR-](https://github.com/JonasR-) (author)
+[smaisidoro](https://github.com/sergioisidoro)

--- a/custom_components/ruuvi/__init__.py
+++ b/custom_components/ruuvi/__init__.py
@@ -1,0 +1,1 @@
+"""Ruuvi sensor integration."""

--- a/custom_components/ruuvi/manifest.json
+++ b/custom_components/ruuvi/manifest.json
@@ -1,0 +1,9 @@
+
+{
+    "domain": "ruuvi",
+    "name": "Ruuvi tag Sensor",
+    "documentation": "https://github.com/JonasR-/ruuvi_hass",
+    "dependencies": [],
+    "codeowners": [],
+    "requirements": ["ruuvitag_sensor"]
+  }

--- a/custom_components/ruuvi/manifest.json
+++ b/custom_components/ruuvi/manifest.json
@@ -4,6 +4,6 @@
     "name": "Ruuvi tag Sensor",
     "documentation": "https://github.com/JonasR-/ruuvi_hass",
     "dependencies": [],
-    "codeowners": [],
+    "codeowners": ["@JonasR", "@salleq", "@PieterGit", "@smaisidoro"],
     "requirements": ["ruuvitag_sensor"]
   }

--- a/custom_components/ruuvi/sensor.py
+++ b/custom_components/ruuvi/sensor.py
@@ -11,6 +11,8 @@ from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC
 )
 
+from ruuvitag_sensor.ruuvi import RuuviTagSensor
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ADAPTER = 'adapter'
@@ -44,7 +46,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    from ruuvitag_sensor.ruuvi import RuuviTagSensor
 
     mac_addresses = config.get(CONF_MAC)
     if not isinstance(mac_addresses, list):

--- a/custom_components/ruuvi/sensor.py
+++ b/custom_components/ruuvi/sensor.py
@@ -11,8 +11,6 @@ from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC
 )
 
-REQUIREMENTS = ['ruuvitag_sensor']
-
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ADAPTER = 'adapter'


### PR DESCRIPTION
This restructures the custom component to use the [sensor template](https://github.com/home-assistant/example-custom-config/tree/master/custom_components/example_sensor)

Also the configs for the adapter were there, but the were not being passed to ruuvi lib. 
Fixes #1

PS: Took the liberty to add a contributors section :)